### PR TITLE
all images v21.08 -> 21.08.6, SLURM build v23-02-6-1 -> 21-08-6-1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,11 +14,11 @@ services:
       - var_lib_mysql:/var/lib/mysql
 
   slurmdbd:
-    image: slurm-docker-cluster:${IMAGE_TAG:-21.08}
+    image: slurm-docker-cluster:${IMAGE_TAG:-21.08.6}
     build:
       context: .
       args:
-        SLURM_TAG: ${SLURM_TAG:-slurm-23-02-6-1}
+        SLURM_TAG: ${SLURM_TAG:-slurm-21-08-6-1}
     command: [ "slurmdbd" ]
     container_name: slurmdbd
     hostname: slurmdbd
@@ -35,7 +35,7 @@ services:
       - mysql
 
   slurmctld:
-    image: slurm-docker-cluster:${IMAGE_TAG:-21.08}
+    image: slurm-docker-cluster:${IMAGE_TAG:-21.08.6}
     command: [ "slurmctld" ]
     container_name: slurmctld
     hostname: slurmctld
@@ -53,7 +53,7 @@ services:
       - "slurmdbd"
 
   c1:
-    image: slurm-docker-cluster:${IMAGE_TAG:-21.08}
+    image: slurm-docker-cluster:${IMAGE_TAG:-21.08.6}
     command: [ "slurmd" ]
     hostname: c1
     container_name: c1
@@ -71,7 +71,7 @@ services:
       - "slurmctld"
 
   c2:
-    image: slurm-docker-cluster:${IMAGE_TAG:-21.08}
+    image: slurm-docker-cluster:${IMAGE_TAG:-21.08.6}
     entrypoint: [ "sh", "-c" ]
     command: [ "/usr/share/bin/slurm-interface.sh" ]
     hostname: c2


### PR DESCRIPTION
In our ongoing quest to fix the c1 container failing on Macbook ARM chips, I bumped the version number for all images and downgraded the SLURM build inside the slurmdbd.

Pro: c1 container now runs
Con: c2 container no longer runs

c2 container logs:
```
-- slurmctld is not available.  Sleeping ...
-- slurmctld is not available.  Sleeping ...
-- slurmctld is not available.  Sleeping ...
-- slurmctld is now active ...
 Nothing new added.
 Nothing new added.
slurmrestd: fatal: Unexpected value in SLURMRESTD_SECURITY=disable_unshare_files
```